### PR TITLE
Use OSR in preference to the SET instruction

### DIFF
--- a/pimoroni-blinkt/blinkt_solid_colour.pio
+++ b/pimoroni-blinkt/blinkt_solid_colour.pio
@@ -21,18 +21,21 @@ forever:
   mov isr, osr side 0
 
   set x, 31 side 0
+  mov osr, null side 0
 start_sequence_loop:
-  set pins, 0 side 1
+  out pins, 1 side 1
   jmp x-- start_sequence_loop side 0
 
   set y, 7 side 0
 led_loop:
-  out null, 3 side 0  ; Discard the 3 most significant bits - they are are not used
-
   set x, 2 side 0
+  mov osr, ~ null side 0
 msb_loop:
-  set pins, 1 side 1
+  out pins, 1 side 1
   jmp x-- msb_loop side 0
+
+  mov osr, isr side 0 ; Restore the output shift register to the value from the FIFO
+  out null, 3 side 0  ; Discard the 3 most significant bits - they are are not used
 
   set x, 4 side 0
 brightness_loop:
@@ -48,8 +51,9 @@ bgr_loop:
   jmp y-- led_loop side 0
 
   set x, 31 side 0
+  mov osr, null side 0
 end_sequence_loop:
-  set pins, 0 side 1
+  out pins, 1 side 1
   jmp x-- end_sequence_loop side 0
 
   jmp forever side 0

--- a/pimoroni-blinkt/blinkt_solid_colour.py
+++ b/pimoroni-blinkt/blinkt_solid_colour.py
@@ -20,7 +20,7 @@ from time import sleep
 CLOCK_PIN = board.GP19
 DATA_PIN = board.GP18
 
-BRIGHTNESS = 2
+BRIGHTNESS = 1
 PIXEL_VALUES = [
     (BRIGHTNESS << 24) | 0x0000FF,
     (BRIGHTNESS << 24) | 0x00FF00,
@@ -33,7 +33,7 @@ def assemble_program(filename):
         return assemble(file.read())
 
 
-state_machine = rp2pio.StateMachine(
+with rp2pio.StateMachine(
     assemble_program("blinkt_solid_colour.pio"),
     frequency=2_000_000,
     first_out_pin=DATA_PIN,
@@ -44,9 +44,8 @@ state_machine = rp2pio.StateMachine(
     sideset_pin_count=1,
     initial_set_pin_direction=3,
     out_shift_right=False,
-)
-
-while True:
-    for pixel_value in PIXEL_VALUES:
-        state_machine.write(array.array("I", [pixel_value]))
-        sleep(1)
+) as state_machine:
+    while True:
+        for pixel_value in PIXEL_VALUES:
+            state_machine.write(array.array("I", [pixel_value]))
+            sleep(1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ pluggy==0.13.1
 py==1.10.0
 pyparsing==2.4.7
 pytest==6.2.4
-rp2040-pio-emulator==0.19.0
+rp2040-pio-emulator==0.20.0
 toml==0.10.2
 typing-extensions==3.10.0.0
 zipp==3.4.1


### PR DESCRIPTION
Updated Blinkt! example to use the output shift register instead of the
SET instruction. This reduces the number of pin-sets by one.

NB The exception to this is the configuration of the initial pin
directions.